### PR TITLE
Test on latest stable Julia version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7'
+          - '1.6'
+          - '1'
           # - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
The package supports Julia v1.6 and above, so the tests should ideally be run on v1.6 and the latest stable version.