### PR TITLE
reduce allocations in generic_fft

### DIFF
--- a/src/fft.jl
+++ b/src/fft.jl
@@ -342,21 +342,28 @@ function interlace(a::AbstractVector{S},b::AbstractVector{V}) where {S<:Number,V
     end
 end
 
+"""
+Interlace `v::AbstractVector` with complex entries as
+
+    [(r1,i1), (r2,i2), (r2,i3), ...] -> [r1,i1,r2,i2,r3,i3,...]
+    
+with `r,i` the real and imaginary part of every element in `v`."""
 function interlace_complex(a::AbstractVector{S}, conjfn = identity) where {S<:Complex}
-    n=length(a)
-    ret=zeros(real(S),2n)
-    for (i, ai) in enumerate(a)
-        ret[2i-1] = real(ai)
-        ret[2i] = conjfn(imag(ai))
+    n = length(a)
+    a_interlaced = zeros(real(S),2n)
+    @inbounds for (i, ai) in enumerate(a)
+        a_interlaced[2i-1] = real(ai)
+        a_interlaced[2i] = conjfn(imag(ai))
     end
-    ret
+    return a_interlaced
 end
 
-function deinterlace_complex(a::AbstractVector{S}, conjfn = identity) where {S<:Real}
+"""Reverse function of interlace_complex."""
+function deinterlace_complex(a_interlaced::AbstractVector{S}, conjfn = identity) where {S<:Real}
     n = length(a)
-    ret = zeros(Complex{S}, n ÷ 2)
-    for i in eachindex(ret)
-        ret[i] = complex(a[2i-1], conjfn(a[2i]))
+    a = zeros(Complex{S}, n ÷ 2)        # deinterlaced vector
+    @inbounds for i in eachindex(a)     # ignores last entry if length(a_interlaced) odd
+        a[i] = complex(a_interlaced[2i-1], conjfn(a_interlaced[2i]))
     end
-    ret
+    return a
 end

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -324,23 +324,24 @@ plan_brfft(x::StridedArray{T}, n::Integer, region) where {T <: ComplexFloats} = 
 # plan_rfft!(x::StridedArray{T}) where {T <: RealFloats} = DummyrFFTPlan{Complex{real(T)},true}()
 # plan_irfft!(x::StridedArray{T},n::Integer) where {T <: RealFloats} = DummyirFFTPlan{Complex{real(T)},true}()
 
-function interlace(a::AbstractVector{S},b::AbstractVector{V}) where {S<:Number,V<:Number}
-    na=length(a);nb=length(b)
-    T=promote_type(S,V)
-    if nb≥na
-        ret=zeros(T,2nb)
-        ret[1:2:1+2*(na-1)]=a
-        ret[2:2:end]=b
-        ret
-    else
-        ret=zeros(T,2na-1)
-        ret[1:2:end]=a
-        if !isempty(b)
-            ret[2:2:2+2*(nb-1)]=b
-        end
-        ret
-    end
-end
+# old version deprecated in favour of interlace_complex, deinterlace_complex below
+# function interlace(a::AbstractVector{S},b::AbstractVector{V}) where {S<:Number,V<:Number}
+#     na=length(a);nb=length(b)
+#     T=promote_type(S,V)
+#     if nb≥na
+#         ret=zeros(T,2nb)
+#         ret[1:2:1+2*(na-1)]=a
+#         ret[2:2:end]=b
+#         ret
+#     else
+#         ret=zeros(T,2na-1)
+#         ret[1:2:end]=a
+#         if !isempty(b)
+#             ret[2:2:2+2*(nb-1)]=b
+#         end
+#         ret
+#     end
+# end
 
 """
 Interlace `a::AbstractVector` with complex entries as

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -343,11 +343,11 @@ function interlace(a::AbstractVector{S},b::AbstractVector{V}) where {S<:Number,V
 end
 
 """
-Interlace `v::AbstractVector` with complex entries as
+Interlace `a::AbstractVector` with complex entries as
 
     [(r1,i1), (r2,i2), (r2,i3), ...] -> [r1,i1,r2,i2,r3,i3,...]
     
-with `r,i` the real and imaginary part of every element in `v`."""
+with `r,i` the real and imaginary part of every element in `a`."""
 function interlace_complex(a::AbstractVector{S}, conjfn = identity) where {S<:Complex}
     n = length(a)
     a_interlaced = zeros(real(S),2n)
@@ -360,7 +360,7 @@ end
 
 """Reverse function of interlace_complex."""
 function deinterlace_complex(a_interlaced::AbstractVector{S}, conjfn = identity) where {S<:Real}
-    n = length(a)
+    n = length(a_interlaced)
     a = zeros(Complex{S}, n ÷ 2)        # deinterlaced vector
     @inbounds for i in eachindex(a)     # ignores last entry if length(a_interlaced) odd
         a[i] = complex(a_interlaced[2i-1], conjfn(a_interlaced[2i]))

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -134,16 +134,16 @@ function generic_fft_pow2!(x::AbstractVector{T}) where T<:AbstractFloat
 end
 
 function generic_fft_pow2(x::AbstractVector{Complex{T}}) where T<:AbstractFloat
-    y = interlacereim(x)
+    y = interlace_complex(x)
     generic_fft_pow2!(y)
-    return deinterlacereim(y)
+    return deinterlace_complex(y)
 end
 generic_fft_pow2(x::AbstractVector{T}) where T<:AbstractFloat = generic_fft_pow2(complex(x))
 
 function generic_ifft_pow2(x::AbstractVector{Complex{T}}) where T<:AbstractFloat
-    y = interlacereim(x, -)
+    y = interlace_complex(x, -)
     generic_fft_pow2!(y)
-    return ldiv!(T(length(x)), deinterlacereim(y, -))
+    return ldiv!(T(length(x)), deinterlace_complex(y, -))
 end
 
 function generic_dct(x::StridedVector{T}, region::Integer) where T<:AbstractFloats
@@ -342,7 +342,7 @@ function interlace(a::AbstractVector{S},b::AbstractVector{V}) where {S<:Number,V
     end
 end
 
-function interlacereim(a::AbstractVector{S}, conjfn = identity) where {S<:Complex}
+function interlace_complex(a::AbstractVector{S}, conjfn = identity) where {S<:Complex}
     n=length(a)
     ret=zeros(real(S),2n)
     for (i, ai) in enumerate(a)
@@ -352,7 +352,7 @@ function interlacereim(a::AbstractVector{S}, conjfn = identity) where {S<:Comple
     ret
 end
 
-function deinterlacereim(a::AbstractVector{S}, conjfn = identity) where {S<:Real}
+function deinterlace_complex(a::AbstractVector{S}, conjfn = identity) where {S<:Real}
     n = length(a)
     ret = zeros(Complex{S}, n ÷ 2)
     for i in eachindex(ret)

--- a/test/interlace.jl
+++ b/test/interlace.jl
@@ -4,20 +4,20 @@
 
             # deinterlace(interlace)
             v = rand(Complex{F},n)
-            v_interlaced = interlace_complex(v)
-            v2 = deinterlace_complex(v_interlaced)
+            v_interlaced = GenericFFT.interlace_complex(v)
+            v2 = GenericFFT.deinterlace_complex(v_interlaced)
             @test v == v2
 
             # and interlace(deinterlace)
             v_interlaced = rand(F,2n)
-            v = deinterlace_complex(v_interlaced)
-            v_interlaced2 = interlace_complex(v)
+            v = GenericFFT.deinterlace_complex(v_interlaced)
+            v_interlaced2 = GenericFFT.interlace_complex(v)
             @test v_interlaced == v_interlaced2
 
             # odd interlaced vectors (shouldn't be produced and will ignore last element)
             v_interlaced = rand(F,2n+1)
-            v = deinterlace_complex(v_interlaced)   # [end] ignored here
-            v_interlaced2 = interlace_complex(v)
+            v = GenericFFT.deinterlace_complex(v_interlaced)   # [end] ignored here
+            v_interlaced2 = GenericFFT.interlace_complex(v)
             @test v_interlaced[1:end-1] == v_interlaced2
         end
     end

--- a/test/interlace.jl
+++ b/test/interlace.jl
@@ -1,0 +1,24 @@
+@testset "interlace complex vectors" begin
+    for F in (Float16, Float32, Float64)
+        for n in (4,7,8,9,12,14,16)
+
+            # deinterlace(interlace)
+            v = rand(Complex{F},n)
+            v_interlaced = interlace_complex(v)
+            v2 = deinterlace_complex(v_interlaced)
+            @test v == v2
+
+            # and interlace(deinterlace)
+            v_interlaced = rand(F,2n)
+            v = deinterlace_complex(v_interlaced)
+            v_interlaced2 = interlace_complex(v)
+            @test v_interlaced == v_interlaced2
+
+            # odd interlaced vectors (shouldn't be produced and will ignore last element)
+            v_interlaced = rand(F,2n+1)
+            v = deinterlace_complex(v_interlaced)   # [end] ignored here
+            v_interlaced2 = interlace_complex(v)
+            @test v_interlaced[1:end-1] == v_interlaced2
+        end
+    end
+end

--- a/test/interlace.jl
+++ b/test/interlace.jl
@@ -1,24 +1,26 @@
 @testset "interlace complex vectors" begin
-    for F in (Float16, Float32, Float64)
-        for n in (4,7,8,9,12,14,16)
+    for op in (identity,-)
+        for F in (Float16, Float32, Float64)
+            for n in (4,7,8,9,12,14,16)
 
-            # deinterlace(interlace)
-            v = rand(Complex{F},n)
-            v_interlaced = GenericFFT.interlace_complex(v)
-            v2 = GenericFFT.deinterlace_complex(v_interlaced)
-            @test v == v2
+                # deinterlace(interlace)
+                v = rand(Complex{F},n)
+                v_interlaced = GenericFFT.interlace_complex(v,op)
+                v2 = GenericFFT.deinterlace_complex(v_interlaced,op)
+                @test v == v2
 
-            # and interlace(deinterlace)
-            v_interlaced = rand(F,2n)
-            v = GenericFFT.deinterlace_complex(v_interlaced)
-            v_interlaced2 = GenericFFT.interlace_complex(v)
-            @test v_interlaced == v_interlaced2
+                # and interlace(deinterlace)
+                v_interlaced = rand(F,2n)
+                v = GenericFFT.deinterlace_complex(v_interlaced,op)
+                v_interlaced2 = GenericFFT.interlace_complex(v,op)
+                @test v_interlaced == v_interlaced2
 
-            # odd interlaced vectors (shouldn't be produced and will ignore last element)
-            v_interlaced = rand(F,2n+1)
-            v = GenericFFT.deinterlace_complex(v_interlaced)   # [end] ignored here
-            v_interlaced2 = GenericFFT.interlace_complex(v)
-            @test v_interlaced[1:end-1] == v_interlaced2
+                # odd interlaced vectors (shouldn't be produced and will ignore last element)
+                v_interlaced = rand(F,2n+1)
+                v = GenericFFT.deinterlace_complex(v_interlaced,op)   # [end] ignored here
+                v_interlaced2 = GenericFFT.interlace_complex(v,op)
+                @test v_interlaced[1:end-1] == v_interlaced2
+            end
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,4 @@
-
 using AbstractFFTs, GenericFFT, Test
-
 
 @test AbstractFFTs.fftfloat(zero(Float16)) isa Float32
 @test AbstractFFTs.fftfloat(zero(Float32)) isa Float32
@@ -11,6 +9,6 @@ using AbstractFFTs, GenericFFT, Test
 @test AbstractFFTs.fftfloat(zero(Complex{Float64})) isa Complex{Float64}
 @test AbstractFFTs.fftfloat(zero(Complex{BigFloat})) isa Complex{BigFloat}
 
-
 include("fft_tests.jl")
 include("toeplitz_tests.jl")
+include("interlace.jl")


### PR DESCRIPTION
On main
```julia
julia> v = rand(10025);

julia> @btime GenericFFT.generic_fft($v);
  7.006 ms (71 allocations: 10.17 MiB)
```
This PR
```julia
julia> @btime GenericFFT.generic_fft($v);
  6.467 ms (41 allocations: 6.15 MiB)
```